### PR TITLE
[FIX] Filtering traffic on port 8444 so chia nodes are not accepted

### DIFF
--- a/chaingreen/full_node/full_node.py
+++ b/chaingreen/full_node/full_node.py
@@ -477,6 +477,10 @@ class FullNode:
         if self.full_node_peers is not None:
             asyncio.create_task(self.full_node_peers.on_connect(connection))
 
+        if connection.peer_port == 8444 or connection.peer_server_port == 8444:
+            self.log.warning(f"Removing Chia peer {connection.peer_host} {connection.peer_port}")
+            return None
+            
         if self.initialized is False:
             return None
 

--- a/chaingreen/server/node_discovery.py
+++ b/chaingreen/server/node_discovery.py
@@ -247,7 +247,7 @@ class FullNodeDiscovery:
                     peer = conn.get_peer_info()
                     if peer is None:
                         continue
-                    if peer.port == 8444:
+                    if peer.port == 8444 or conn.server_port == 8444:
                         continue
                     group = peer.get_group()
                     if group not in groups:

--- a/chaingreen/server/node_discovery.py
+++ b/chaingreen/server/node_discovery.py
@@ -247,6 +247,8 @@ class FullNodeDiscovery:
                     peer = conn.get_peer_info()
                     if peer is None:
                         continue
+                    if peer.port == 8444:
+                        continue
                     group = peer.get_group()
                     if group not in groups:
                         groups.append(group)

--- a/chaingreen/server/server.py
+++ b/chaingreen/server/server.py
@@ -256,7 +256,10 @@ class ChaingreenServer:
 
             assert handshake is True
 
-            if connection.peer_port == 8444:
+            self.log.warning(f"Connecting peer {connection.get_peer_info()}")
+
+            if connection.peer_port == 8444 or connection.peer_server_port == 8444:
+                
                 self.log.info(f"Stop communicating with Chia node: {connection.get_peer_info()}")
                 await connection.close()
                 close_event.set()

--- a/chaingreen/server/server.py
+++ b/chaingreen/server/server.py
@@ -255,6 +255,12 @@ class ChaingreenServer:
             )
 
             assert handshake is True
+
+            if connection.peer_port == 8444:
+                self.log.info(f"Stop communicating with Chia node: {connection.get_peer_info()}")
+                await connection.close()
+                close_event.set()
+
             # Limit inbound connections to config's specifications.
             if not self.accept_inbound_connections(connection.connection_type) and not is_in_network(
                 connection.peer_host, self.exempt_peer_networks
@@ -328,6 +334,9 @@ class ChaingreenServer:
         An on connect method can also be specified, and this will be saved into the instance variables.
         """
         if self.is_duplicate_or_self_connection(target_node):
+            return False
+
+        if target_node.port == 8444:
             return False
 
         if target_node.host in self.banned_peers and time.time() < self.banned_peers[target_node.host]:

--- a/chaingreen/server/ws_connection.py
+++ b/chaingreen/server/ws_connection.py
@@ -124,6 +124,8 @@ class WSChaingreenConnection:
             inbound_handshake = Handshake.from_bytes(inbound_handshake_msg.data)
             if ProtocolMessageTypes(inbound_handshake_msg.type) != ProtocolMessageTypes.handshake:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
+            if inbound_handshake.server_port == 8444:
+                raise ProtocolError(Err.INVALID_HANDSHAKE)
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)
 
@@ -135,11 +137,12 @@ class WSChaingreenConnection:
                 message = await self._read_one_message()
             except Exception:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
-
             if message is None:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
             inbound_handshake = Handshake.from_bytes(message.data)
             if ProtocolMessageTypes(message.type) != ProtocolMessageTypes.handshake:
+                raise ProtocolError(Err.INVALID_HANDSHAKE)
+            if inbound_handshake.server_port == 8444:
                 raise ProtocolError(Err.INVALID_HANDSHAKE)
             if inbound_handshake.network_id != network_id:
                 raise ProtocolError(Err.INCOMPATIBLE_NETWORK_ID)


### PR DESCRIPTION
## Incentive 
Chia nodes are connecting to chaingreen because of peers with incorrect configurations. This PR is adding a filter for everything on port 8444 so that doesn't happen. 

## Solution
Skipping the connection to and from port 8444 on any IP address. That way there is a small chance for Chia nodes to connect to chaingreen nodes. This fix is not breaking the current protocol and is compatible with previous versions. 