### PR TITLE
[Feature] Increasing the max difficulty change because of extremely fast growing network

### DIFF
--- a/chaingreen/consensus/constants.py
+++ b/chaingreen/consensus/constants.py
@@ -19,6 +19,8 @@ class ConsensusConstants:
     DIFFICULTY_STARTING: uint64  # The difficulty for the first epoch
     # The maximum factor by which difficulty and sub_slot_iters can change per epoch
     DIFFICULTY_CHANGE_MAX_FACTOR: uint32
+    DIFFICULTY_CHANGE_MAX_FACTOR_v1_2_0: uint32
+    v1_2_0_ACTIVATION_BLOCK: uint64
     SUB_EPOCH_BLOCKS: uint32  # The number of blocks per sub-epoch
     EPOCH_BLOCKS: uint32  # The number of blocks per sub-epoch, must be a multiple of SUB_EPOCH_BLOCKS
 

--- a/chaingreen/consensus/default_constants.py
+++ b/chaingreen/consensus/default_constants.py
@@ -13,6 +13,8 @@ testnet_kwargs = {
     "DIFFICULTY_CONSTANT_FACTOR": 2 ** 20,
     "DIFFICULTY_STARTING": 1,
     "DIFFICULTY_CHANGE_MAX_FACTOR": 3,  # The next difficulty is truncated to range [prev / FACTOR, prev * FACTOR]
+    "DIFFICULTY_CHANGE_MAX_FACTOR_v1_2_0": 81,  # This difficulty change to be applied with v1.2.0
+    "v1_2_0_ACTIVATION_BLOCK": 161280,  # activation of v1.2.0 rules height
     # These 3 constants must be changed at the same time
     "SUB_EPOCH_BLOCKS": 384,  # The number of blocks per sub-epoch, mainnet 384
     "EPOCH_BLOCKS": 4608,  # The number of blocks per epoch, mainnet 4608. Must be multiple of SUB_EPOCH_BLOCKS

--- a/chaingreen/consensus/default_constants.py
+++ b/chaingreen/consensus/default_constants.py
@@ -14,7 +14,7 @@ testnet_kwargs = {
     "DIFFICULTY_STARTING": 1,
     "DIFFICULTY_CHANGE_MAX_FACTOR": 3,  # The next difficulty is truncated to range [prev / FACTOR, prev * FACTOR]
     "DIFFICULTY_CHANGE_MAX_FACTOR_v1_2_0": 81,  # This difficulty change to be applied with v1.2.0
-    "v1_2_0_ACTIVATION_BLOCK": 161280,  # activation of v1.2.0 rules height
+    "v1_2_0_ACTIVATION_BLOCK": 165888,  # activation of v1.2.0 rules height
     # These 3 constants must be changed at the same time
     "SUB_EPOCH_BLOCKS": 384,  # The number of blocks per sub-epoch, mainnet 384
     "EPOCH_BLOCKS": 4608,  # The number of blocks per epoch, mainnet 4608. Must be multiple of SUB_EPOCH_BLOCKS

--- a/chaingreen/consensus/difficulty_adjustment.py
+++ b/chaingreen/consensus/difficulty_adjustment.py
@@ -254,9 +254,13 @@ def _get_next_sub_slot_iters(
         // (last_block_curr.timestamp - last_block_prev.timestamp)
     )
 
+    difficulty_max_change_factor = constants.DIFFICULTY_CHANGE_MAX_FACTOR
+    if height >= constants.v1_2_0_ACTIVATION_BLOCK:
+        difficulty_max_change_factor = constants.DIFFICULTY_CHANGE_MAX_FACTOR_v1_2_0
+
     # Only change by a max factor as a sanity check
-    max_ssi = uint64(constants.DIFFICULTY_CHANGE_MAX_FACTOR * last_block_curr.sub_slot_iters)
-    min_ssi = uint64(last_block_curr.sub_slot_iters // constants.DIFFICULTY_CHANGE_MAX_FACTOR)
+    max_ssi = uint64(difficulty_max_change_factor * last_block_curr.sub_slot_iters)
+    min_ssi = uint64(last_block_curr.sub_slot_iters // difficulty_max_change_factor)
     if new_ssi_precise >= last_block_curr.sub_slot_iters:
         new_ssi_precise = uint64(min(new_ssi_precise, max_ssi))
     else:
@@ -339,9 +343,13 @@ def _get_next_difficulty(
         // (constants.SLOT_BLOCKS_TARGET * actual_epoch_time)
     )
 
+    difficulty_max_change_factor = constants.DIFFICULTY_CHANGE_MAX_FACTOR
+    if height >= constants.v1_2_0_ACTIVATION_BLOCK:
+        difficulty_max_change_factor = constants.DIFFICULTY_CHANGE_MAX_FACTOR_v1_2_0
+
     # Only change by a max factor, to prevent attacks, as in greenpaper, and must be at least 1
-    max_diff = uint64(constants.DIFFICULTY_CHANGE_MAX_FACTOR * old_difficulty)
-    min_diff = uint64(old_difficulty // constants.DIFFICULTY_CHANGE_MAX_FACTOR)
+    max_diff = uint64(difficulty_max_change_factor * old_difficulty)
+    min_diff = uint64(old_difficulty // difficulty_max_change_factor)
 
     if new_difficulty_precise >= old_difficulty:
         new_difficulty_precise = uint64(min(new_difficulty_precise, max_diff))


### PR DESCRIPTION
# Incentive

The network has been growing exponentially for the last 5 days with a total increase of over 40 000 times. Therefore it's suggested to increase the maximum difficulty growth factor so it's faster to get to the correct difficulty and also stabilise the network sync. 

# Implementation
The change will happen via hard fork on block 161280. From that block on the difficulty will be increasing at most 81 times per 4608 blocks (1 epoch). 