### PR TITLE
gitmodules: use only git over https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/Chia-Network/mozilla-ca.git
 [submodule "chaingreen-blockchain-gui"]
 	path = chaingreen-blockchain-gui
-	url = git@github.com:ChainGreenOrg/chaingreen-blockchain-gui.git
+	url = https://github.com/ChainGreenOrg/chaingreen-blockchain-gui.git


### PR DESCRIPTION
If you haven't setup a local valid ssh key on github, the sync of submodules fails.
Fixes https://github.com/ChainGreenOrg/chaingreen-blockchain/issues/29